### PR TITLE
Fix MSIM incoming call notification handling.

### DIFF
--- a/src/com/android/incallui/StatusBarNotifier.java
+++ b/src/com/android/incallui/StatusBarNotifier.java
@@ -242,14 +242,6 @@ public class StatusBarNotifier implements InCallPresenter.InCallStateListener,
             largeIcon = getRoundedIcon(largeIcon);
         }
 
-        // set the content
-        if (TelephonyManager.getDefault().isMultiSimEnabled()) {
-            SubscriptionInfo info =
-                    SubscriptionManager.from(mContext).getActiveSubscriptionInfo(call.getSubId());
-            if (info != null) {
-                content += " (" + info.getDisplayName() + ")";
-            }
-        }
         /*
          * Nothing more to check...build and send it.
          */
@@ -273,6 +265,14 @@ public class StatusBarNotifier implements InCallPresenter.InCallStateListener,
         builder.setContentTitle(contentTitle);
         builder.setLargeIcon(largeIcon);
         builder.setColor(mContext.getResources().getColor(R.color.dialer_theme_color));
+
+        if (TelephonyManager.getDefault().isMultiSimEnabled()) {
+            SubscriptionManager mgr = SubscriptionManager.from(mContext);
+            SubscriptionInfo subInfoRecord = mgr.getActiveSubscriptionInfo(call.getSubId());
+            if (subInfoRecord != null) {
+                builder.setSubText(subInfoRecord.getDisplayName());
+            }
+        }
 
         if (isVideoUpgradeRequest) {
             builder.setUsesChronometer(false);


### PR DESCRIPTION
There's no need to handle MSIM twice for the notification. Additionally,
the SIM name isn't the most important information in that notification,
so don't treat it as such: Revert to AOSP behaviour (caller name as
title, 'incoming call' as content) and add the SIM name as subtext,
which matches what we already do for incoming SMS.

Change-Id: I4cb8bbb8fa4f44515e8552d6882fb7134978ad37
Signed-off-by: Martinusbe martinusbe@gmail.com

Conflicts:
    src/com/android/incallui/StatusBarNotifier.java

Signed-off-by: Vibhor Chaudhary cvibhu0009@gmail.com
